### PR TITLE
Use dimensions of the element the swipe event is delegated to

### DIFF
--- a/js/jquery.event.swipe.js
+++ b/js/jquery.event.swipe.js
@@ -44,8 +44,8 @@
 	function moveend(e) {
 		var w, h, event;
 
-		w = e.target.offsetWidth;
-		h = e.target.offsetHeight;
+		w = e.delegateTarget.offsetWidth;
+		h = e.delegateTarget.offsetHeight;
 
 		// Copy over some useful properties from the move event
 		event = {


### PR DESCRIPTION
"event.target" matches the DOM element directly under the cursor.
"event.delegateTarget" matches the DOM element ".on" was called on.
