### PR TITLE
Ignore node modules folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules


### PR DESCRIPTION
Ignore node modules folder in git since these dependencies don't need to be committed because they are meant to be installed by npm. When I do npm install, the git recognizes the node_modules folder as untracked.